### PR TITLE
fix(windows): prevent console window on desktop startup

### DIFF
--- a/src/bin/kitter-desktop.rs
+++ b/src/bin/kitter-desktop.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(target_os = "windows", windows_subsystem = "windows")]
+
 fn main() {
     kitter::ui::run();
 }


### PR DESCRIPTION
## What changed

Add the Windows GUI subsystem attribute to the desktop binary so launching
Kitter.exe does not open an empty console window.

为桌面端二进制文件添加了 Windows GUI 子系统属性，以便在启动 Kitter.exe 时不会弹出一个空白的控制台窗口。

## Validation

- Built the Windows release package locally with Rust 1.97.1.
- Confirmed Kitter.exe uses the Windows GUI subsystem.
- Confirmed the bundled CLI remains a console executable.
- macOS and Linux builds are unaffected because the attribute is conditional on Windows.

- 使用 Rust 1.97.1 在本地构建了 Windows 发布包。
- 确认 Kitter.exe 已使用 Windows GUI 子系统。
- 确认附带的命令行工具（CLI）仍然保持为控制台可执行文件。
- macOS 和 Linux 的构建不受影响，因为该属性仅在 Windows 系统下生效。

Fixes #4